### PR TITLE
FreeValueStructのメモリリークを修正

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -160,7 +160,9 @@ extern void FreeValueStruct(ValueStruct *val) {
       if (ValueArrayPrototype(val) != NULL) {
         FreeValueStruct(ValueArrayPrototype(val));
       }
-      xfree(ValueArrayItems(val));
+      if (ValueArrayItems(val) != NULL) {
+        xfree(ValueArrayItems(val));
+      }
       xfree(ValueBody(val));
       break;
     case GL_TYPE_ROOT_RECORD:
@@ -173,8 +175,12 @@ extern void FreeValueStruct(ValueStruct *val) {
         xfree(ValueRecordName(val, i));
       }
       DestroyHashTable(ValueRecordMembers(val));
-      xfree(ValueRecordNames(val));
-      xfree(ValueRecordItems(val));
+      if (ValueRecordNames(val) != NULL) {
+        xfree(ValueRecordNames(val));
+      }
+      if (ValueRecordItems(val) != NULL) {
+        xfree(ValueRecordItems(val));
+      }
       xfree(ValueBody(val));
       break;
     case GL_TYPE_BYTE:
@@ -202,6 +208,11 @@ extern void FreeValueStruct(ValueStruct *val) {
       xfree(ValueFixedBody(val));
       xfree(ValueBody(val));
       break;
+    case GL_TYPE_VALUES:
+      if (ValueValuesItems(val) != NULL) {
+        xfree(ValueValuesItems(val));
+      }
+      xfree(ValueBody(val));
     default:
       break;
     }

--- a/src/value.c
+++ b/src/value.c
@@ -160,6 +160,7 @@ extern void FreeValueStruct(ValueStruct *val) {
       if (ValueArrayPrototype(val) != NULL) {
         FreeValueStruct(ValueArrayPrototype(val));
       }
+      xfree(ValueArrayItems(val));
       xfree(ValueBody(val));
       break;
     case GL_TYPE_ROOT_RECORD:
@@ -172,6 +173,8 @@ extern void FreeValueStruct(ValueStruct *val) {
         xfree(ValueRecordName(val, i));
       }
       DestroyHashTable(ValueRecordMembers(val));
+      xfree(ValueRecordNames(val));
+      xfree(ValueRecordItems(val));
       xfree(ValueBody(val));
       break;
     case GL_TYPE_BYTE:


### PR DESCRIPTION
ユーザからの報告があり、valgrindでwfcのプロセスをチェックしたところDuplicateValueでのリークが見つかった。

* valgrindでwfcのプロセスをチェックし該当のリークがなくなったことを確認
* scan_buildでエラーがないことを確認

valgrindは--leak-check=fullオプションをつけないとメモリリークはチェックしてくれなくなった模様。