### PR TITLE
pandaの画面定義体、DB定義体のメモリ逐次確保、解放のための修正

### DIFF
--- a/src/RecParser.c
+++ b/src/RecParser.c
@@ -473,6 +473,23 @@ static ValueStruct *_RecParseValue(CURFILE *in, char **topname) {
   return ret;
 }
 
+extern ValueStruct *RecParseValueNoCache(const char *name, char **ValueName) {
+  ValueStruct *ret;
+  CURFILE *in, root;
+
+  assert(ParsedRec);
+  root.next = NULL;
+  if ((in = PushLexInfo(&root, name, RecordDir, Reserved)) != NULL) {
+    ret = _RecParseValue(in, ValueName);
+    DropLexInfo(&in);
+    g_hash_table_insert(ParsedRec, StrDup(name), ret);
+  } else {
+    ret = NULL;
+  }
+
+  return (ret);
+}
+
 extern ValueStruct *RecParseValue(const char *name, char **ValueName) {
   ValueStruct *ret;
   CURFILE *in, root;
@@ -480,13 +497,7 @@ extern ValueStruct *RecParseValue(const char *name, char **ValueName) {
   assert(ParsedRec);
   root.next = NULL;
   if ((ret = g_hash_table_lookup(ParsedRec, name)) == NULL) {
-    if ((in = PushLexInfo(&root, name, RecordDir, Reserved)) != NULL) {
-      ret = _RecParseValue(in, ValueName);
-      DropLexInfo(&in);
-      g_hash_table_insert(ParsedRec, StrDup(name), ret);
-    } else {
-      ret = NULL;
-    }
+    ret = RecParseValueNoCache(name,ValueName);
   } else {
     if (ValueName != NULL) {
       *ValueName = GetValueName(ret);

--- a/src/RecParser.c
+++ b/src/RecParser.c
@@ -477,12 +477,10 @@ extern ValueStruct *RecParseValueNoCache(const char *name, char **ValueName) {
   ValueStruct *ret;
   CURFILE *in, root;
 
-  assert(ParsedRec);
   root.next = NULL;
   if ((in = PushLexInfo(&root, name, RecordDir, Reserved)) != NULL) {
     ret = _RecParseValue(in, ValueName);
     DropLexInfo(&in);
-    g_hash_table_insert(ParsedRec, StrDup(name), ret);
   } else {
     ret = NULL;
   }
@@ -492,12 +490,11 @@ extern ValueStruct *RecParseValueNoCache(const char *name, char **ValueName) {
 
 extern ValueStruct *RecParseValue(const char *name, char **ValueName) {
   ValueStruct *ret;
-  CURFILE *in, root;
 
   assert(ParsedRec);
-  root.next = NULL;
   if ((ret = g_hash_table_lookup(ParsedRec, name)) == NULL) {
     ret = RecParseValueNoCache(name,ValueName);
+    g_hash_table_insert(ParsedRec, StrDup(name), ret);
   } else {
     if (ValueName != NULL) {
       *ValueName = GetValueName(ret);

--- a/src/RecParser.h
+++ b/src/RecParser.h
@@ -29,6 +29,7 @@ extern ValueStruct *ParValueDefine(CURFILE *in);
 extern void SetValueAttribute(ValueStruct *val, ValueAttributeType attr);
 extern void RecParserInit(void);
 extern ValueStruct *RecParseValue(const char *name, char **ValueName);
+extern ValueStruct *RecParseValueNoCache(const char *name, char **ValueName);
 extern ValueStruct *RecParseValueMem(const char *mem, char **ValueName);
 extern ValueStruct *RecParseMain(CURFILE *in);
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -37,6 +37,9 @@
 #include "memory_v.h"
 #include "lock.h"
 #include "debug.h"
+#ifdef MON_MEM_TRACE
+#include <malloc.h>
+#endif
 
 typedef struct {
   LOCKOBJECT;
@@ -44,6 +47,7 @@ typedef struct {
 } POOLMGR;
 
 static POOLMGR *PoolTable = NULL;
+static unsigned long TotalFreeSize = 0;
 
 #ifdef TRACE
 static size_t total = 0;
@@ -98,6 +102,9 @@ extern void _xfree(void *p, char *fn, int line) {
 #else
   if (p == NULL)
     return;
+#ifdef MON_MEM_TRACE
+  TotalFreeSize += malloc_usable_size(p);
+#endif
   free(p);
 #endif
 }
@@ -241,4 +248,12 @@ extern void ReleaseAllPool(void) {
     DestroyLock(PoolTable);
   }
   PoolTable = NULL;
+}
+
+extern void ResetTotalFreeSize(void) {
+  TotalFreeSize = 0;
+}
+
+extern unsigned long GetTotalFreeSize(void) {
+  return TotalFreeSize;
 }

--- a/src/memory_v.h
+++ b/src/memory_v.h
@@ -47,6 +47,8 @@ extern void _ReleasePool(POOL *pool);
 extern POOL *NewPool(char *name);
 extern void InitPool(void);
 extern void SetFinalizer(void *p, AreaFinalizerFunc func, void *data);
+extern void ResetTotalFreeSize();
+extern unsigned long GetTotalFreeSize();
 
 #define GetAreaByPool(p, s) _GetArea((p), (s), __FILE__, __LINE__)
 #define GetAreaByName(n, s) _GetArea(GetPool(n), (s), __FILE__, __LINE__)


### PR DESCRIPTION
RecParseValueNoCache()とメモリ計測機能の追加