### PR TITLE
.から始まるファイルがあるとディレクトリが削除されない

### DIFF
--- a/src/fileutils.c
+++ b/src/fileutils.c
@@ -58,7 +58,9 @@ extern Bool rm_r(char *dname) {
       /* directory */
       if ((dir = opendir(dname)) != NULL) {
         while ((ent = readdir(dir)) != NULL) {
-          if (ent->d_name[0] != '.') {
+          if (strcmp(".",ent->d_name) == 0 || strcmp("..",ent->d_name) == 0) {
+            // skip
+          } else {
             snprintf(path, sizeof(path), "%s/%s", dname, ent->d_name);
             path[sizeof(path) - 1] = 0;
             if (!rm_r(path)) {


### PR DESCRIPTION
* scan-buildの確認
* testfileutlsでrm_rが動作することを確認
    * https://github.com/montsuqi/libmondai/blob/master/src/testfileutils.c