### PR TITLE
utf8->euc-jisx0213変換時に不正なバイト列を?に置き換える

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ src/test.native*
 src/testjson
 src/testnumeric
 src/test.SOAP
+src/testOpenCOBOLPack
 tools/monconv
 tools/rec2copy
 *.swp

--- a/src/Lex.c
+++ b/src/Lex.c
@@ -376,7 +376,7 @@ retry:
         in->Token = '/';
       } else {
         do {
-          while ((c = GetChar(in)) != '*')
+          while (GetChar(in) != '*')
             ;
           if ((c = GetChar(in)) == '/')
             break;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,8 @@ noinst_PROGRAMS =	\
 	testmem \
 	testNativePack \
 	testjson \
-	testnumeric
+	testnumeric \
+	testOpenCOBOLPack
 
 libmondai_la_LDFLAGS	=	\
 	-version-info $(LTVERSION)	\
@@ -133,5 +134,8 @@ testjson_SOURCES		=		\
 
 testnumeric_SOURCES		=		\
 	testnumeric.c
+
+testOpenCOBOLPack_SOURCES		=		\
+	testOpenCOBOLPack.c
 
 EXTRA_DIST = lgpl testrec.rec testinc.rec

--- a/src/Native.c
+++ b/src/Native.c
@@ -201,7 +201,9 @@ extern size_t NativeUnPackValue(CONVOPT *opt, unsigned char *p,
       for (i = 0; i < ValueArraySize(value); i++) {
         dbgprintf("child[%d]", i);
         rc = NativeUnPackValue(opt, p, ValueArrayItem(value, i));
-        ValueParent(ValueArrayItem(value, i)) = value;
+        if (ValueArrayItem(value, i) != NULL) {
+          ValueParent(ValueArrayItem(value, i)) = value;
+        }
         if (rc > 0) {
           p += rc;
         } else {
@@ -222,7 +224,9 @@ extern size_t NativeUnPackValue(CONVOPT *opt, unsigned char *p,
         dbgprintf("child[%d][%s]", i, p);
         p += strlen(p) + 1;
         rc = NativeUnPackValue(opt, p, ValueRecordItem(value, i));
-        ValueParent(ValueRecordItem(value, i)) = value;
+        if (ValueRecordItem(value, i) != NULL) {
+          ValueParent(ValueRecordItem(value, i)) = value;
+        }
         dbgprintf("rc[%d]", rc);
         if (rc > 0) {
           p += rc;

--- a/src/testOpenCOBOLPack.c
+++ b/src/testOpenCOBOLPack.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libmondai.h>
+#include <RecParser.h>
+
+const char *recdef = ""
+                     "test_ {\n"
+                     "  str varchar(128);\n"
+                     "};";
+
+/*euc-jisx0213範囲外の文字が?の列になること*/
+int main(int argc, char *argv[]) {
+
+  ValueStruct *value, *v;
+  size_t size;
+  char *buf;
+  const char *src = "\xE3\x90\x83あいう\xF0\xA0\xAE\xB7えお\xE3\x90\x83かき\xE3\x90\x83﨑髙";
+  FILE *fp;
+
+  CONVOPT *opt = NewConvOpt();
+  ConvSetSize(opt, 1024, 10);
+  ConvSetCodeset(opt, "euc-jisx0213");
+  buf = (unsigned char *)xmalloc(SIZE_BUFF);
+  memset(buf, 0, SIZE_BUFF);
+
+  RecParserInit();
+  value = RecParseValueMem(recdef, NULL);
+
+  /* valueにstr(utf-8)を設定*/
+  InitializeValue(value);
+  v = GetRecordItem(value, "str");
+  fprintf(stderr,"src:%s\n",src);
+  SetValueString(v, src, NULL);
+
+  /* OpenCOBOL_PackValueでutf8からeuc-jisx0213に変換 */
+  size = OpenCOBOL_PackValue(opt, buf, value);
+  /* euc-jisx0213をファイル出力 */
+  if ((fp = fopen("/tmp/opencobol.txt", "w")) == NULL)
+    exit(1);
+  fwrite(buf, size, 1, fp);
+  fclose(fp);
+
+  /* OpenCOBOL_UnPackValueでeuc-jisx0213からutf8に変換 */
+  OpenCOBOL_UnPackValue(opt, buf, value);
+  v = GetRecordItem(value, "str");
+  fprintf(stderr,"dst:%s\n",ValueToString(v,NULL));
+  xfree(buf);
+
+/*
+src:㐃あいう𠮷えお㐃かき㐃﨑髙
+LBSfunc.c:382:convert 髙 -> ■
+dst:???あいう????えお???かき???﨑■
+*/
+
+  return 0;
+}


### PR DESCRIPTION
* OpenCOBOL_PackValueでのutf-8からeuc-jisx0213への変換の際にjisx0213範囲外の文字などの不正なバイト列があった場合に、?に置き換えるよう修正
* 以前は不正バイト以降を切り捨てていた
    * そのため「つちよし」 𠮷などの不正な文字以降が空白となりエンドユーザが気づかないケースがあった

```
従来     "𠮷田達郎" -> ""
本修正 "𠮷田達郎" -> "????田達郎"
``` 