### PR TITLE
rm_r_old()とrm_r_old_depth()を追加、testfileutils.cを変更

### DIFF
--- a/src/fileutils.c
+++ b/src/fileutils.c
@@ -64,7 +64,6 @@ extern Bool rm_r(char *dname) {
             // skip
           } else {
             snprintf(path, sizeof(path), "%s/%s", dname, ent->d_name);
-            path[sizeof(path) - 1] = 0;
             if (!rm_r(path)) {
               return FALSE;
             }
@@ -142,8 +141,7 @@ unsigned long now(void) {
   return tv.tv_sec * 1000L + tv.tv_usec / 1000L;
 }
 
-void rm_r_old_depth(const char *name, unsigned int elapsed, 
-                    unsigned int level, unsigned int depth) {
+void rm_r_old_depth(const char *name, unsigned int elapsed, int depth) {
   DIR *dir;
   struct dirent *ent;
   struct stat st;
@@ -165,18 +163,17 @@ void rm_r_old_depth(const char *name, unsigned int elapsed,
             // skip
           } else {
             snprintf(path, sizeof(path), "%s/%s", name, ent->d_name);
-            path[sizeof(path) - 1] = 0;
-            rm_r_old_depth(path, elapsed, level+1, depth);
+            rm_r_old_depth(path, elapsed, depth - 1);
           }
         }
         closedir(dir);
-        if ((now - st.st_ctim.tv_sec) > elapsed && level >= depth) {
+        if ((now - st.st_ctim.tv_sec) > elapsed && depth <= 0) {
           remove(name);
         }
       }
     } else {
       /* file */
-      if ((now - st.st_ctim.tv_sec) > elapsed && level >= depth) {
+      if ((now - st.st_ctim.tv_sec) > elapsed && depth <= 0) {
         remove(name);
       }
     }
@@ -184,5 +181,5 @@ void rm_r_old_depth(const char *name, unsigned int elapsed,
 }
 
 void rm_r_old(const char *name, unsigned int elapsed) {
-  rm_r_old_depth(name,elapsed,0,0);
+  rm_r_old_depth(name,elapsed,0);
 }

--- a/src/fileutils.c
+++ b/src/fileutils.c
@@ -33,11 +33,12 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 #include <glib.h>
 #include <errno.h>
 #include <dirent.h>
-#include <time.h>
 
 #include "types.h"
 #include "debug.h"
@@ -141,8 +142,8 @@ unsigned long now(void) {
   return tv.tv_sec * 1000L + tv.tv_usec / 1000L;
 }
 
-void rm_r_old_level(const char *name, unsigned int elapsed, 
-                    unsigned int level, unsigned int rm_level) {
+void rm_r_old_depth(const char *name, unsigned int elapsed, 
+                    unsigned int level, unsigned int depth) {
   DIR *dir;
   struct dirent *ent;
   struct stat st;
@@ -165,17 +166,17 @@ void rm_r_old_level(const char *name, unsigned int elapsed,
           } else {
             snprintf(path, sizeof(path), "%s/%s", name, ent->d_name);
             path[sizeof(path) - 1] = 0;
-            rm_r_old_level(path, elapsed, level+1, rm_level);
+            rm_r_old_depth(path, elapsed, level+1, depth);
           }
         }
         closedir(dir);
-        if ((now - st.st_ctim.tv_sec) > elapsed && level >= rm_level) {
+        if ((now - st.st_ctim.tv_sec) > elapsed && level >= depth) {
           remove(name);
         }
       }
     } else {
       /* file */
-      if ((now - st.st_ctim.tv_sec) > elapsed && level >= rm_level) {
+      if ((now - st.st_ctim.tv_sec) > elapsed && level >= depth) {
         remove(name);
       }
     }
@@ -183,5 +184,5 @@ void rm_r_old_level(const char *name, unsigned int elapsed,
 }
 
 void rm_r_old(const char *name, unsigned int elapsed) {
-  rm_r_old_level(name,elapsed,0,0);
+  rm_r_old_depth(name,elapsed,0,0);
 }

--- a/src/fileutils.h
+++ b/src/fileutils.h
@@ -27,8 +27,8 @@ extern Bool rm_r(char *dname);
 extern Bool mkdir_p(char *dname, int mode);
 extern Bool mkdir_p_clean(char *dir, int mode);
 extern Bool MakeDir(char *dir, int mode);
-extern void rm_r_old_level(const char *name, unsigned int elapsed, 
-  unsigned int level, unsigned int rm_level);
+extern void rm_r_old_depth(const char *name, unsigned int elapsed, 
+  unsigned int level, unsigned int depth);
 extern void rm_r_old(const char *name, unsigned int elapsed);
 
 #endif

--- a/src/fileutils.h
+++ b/src/fileutils.h
@@ -27,8 +27,7 @@ extern Bool rm_r(char *dname);
 extern Bool mkdir_p(char *dname, int mode);
 extern Bool mkdir_p_clean(char *dir, int mode);
 extern Bool MakeDir(char *dir, int mode);
-extern void rm_r_old_depth(const char *name, unsigned int elapsed, 
-  unsigned int level, unsigned int depth);
+extern void rm_r_old_depth(const char *name, unsigned int elapsed, int depth);
 extern void rm_r_old(const char *name, unsigned int elapsed);
 
 #endif

--- a/src/fileutils.h
+++ b/src/fileutils.h
@@ -27,5 +27,8 @@ extern Bool rm_r(char *dname);
 extern Bool mkdir_p(char *dname, int mode);
 extern Bool mkdir_p_clean(char *dir, int mode);
 extern Bool MakeDir(char *dir, int mode);
+extern void rm_r_old_level(const char *name, unsigned int elapsed, 
+  unsigned int level, unsigned int rm_level);
+extern void rm_r_old(const char *name, unsigned int elapsed);
 
 #endif

--- a/src/testfileutils.c
+++ b/src/testfileutils.c
@@ -71,15 +71,15 @@ extern int main(int argc, char **argv) {
   touch(TEST_RM_R_OLD3);
   ls_R();
 
-  fprintf(stderr, "rm_r_old_depth(%s,500,0,2) \n", TEST_RM_R_OLD);
-  rm_r_old_depth(TEST_RM_R_OLD,500,0,2);
+  fprintf(stderr, "rm_r_old_depth(%s,500,2) \n", TEST_RM_R_OLD);
+  rm_r_old_depth(TEST_RM_R_OLD,500,2);
   ls_R();
 
   fprintf(stderr, "sleep(5)\n");
   sleep(5);
 
-  fprintf(stderr, "rm_r_old_depth(%s,4,0,2) \n", TEST_RM_R_OLD);
-  rm_r_old_depth(TEST_RM_R_OLD,4,0,2);
+  fprintf(stderr, "rm_r_old_depth(%s,4,2) \n", TEST_RM_R_OLD);
+  rm_r_old_depth(TEST_RM_R_OLD,4,2);
   ls_R();
 
   return 0;

--- a/src/testfileutils.c
+++ b/src/testfileutils.c
@@ -71,15 +71,15 @@ extern int main(int argc, char **argv) {
   touch(TEST_RM_R_OLD3);
   ls_R();
 
-  fprintf(stderr, "rm_r_old_level(%s,500,0,1) \n", TEST_RM_R_OLD);
-  rm_r_old_level(TEST_RM_R_OLD,500,0,1);
+  fprintf(stderr, "rm_r_old_depth(%s,500,0,2) \n", TEST_RM_R_OLD);
+  rm_r_old_depth(TEST_RM_R_OLD,500,0,2);
   ls_R();
 
   fprintf(stderr, "sleep(5)\n");
   sleep(5);
 
-  fprintf(stderr, "rm_r_old_level(%s,4,0,2) \n", TEST_RM_R_OLD);
-  rm_r_old_level(TEST_RM_R_OLD,4,0,2);
+  fprintf(stderr, "rm_r_old_depth(%s,4,0,2) \n", TEST_RM_R_OLD);
+  rm_r_old_depth(TEST_RM_R_OLD,4,0,2);
   ls_R();
 
   return 0;

--- a/src/testfileutils.c
+++ b/src/testfileutils.c
@@ -22,38 +22,65 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <glib.h>
 #include "fileutils.h"
 
+#define TEST_ROOT_DIR "/tmp/libmondai-test-root"
+#define TEST_MAKE_DIR "/tmp/libmondai-test-root/MakeDir"
+#define TEST_RM_R_OLD "/tmp/libmondai-test-root/rm_r_old"
+#define TEST_RM_R_OLD2 "/tmp/libmondai-test-root/rm_r_old/1"
+#define TEST_RM_R_OLD3 "/tmp/libmondai-test-root/rm_r_old/1/2"
+
+static void touch(const char *path) {
+  char *command = g_strdup_printf("touch %s/test.txt",path);
+  fprintf(stderr, "%s\n", command);
+  system(command);
+  g_free(command);
+}
+
+static void ls_R() {
+  char *command = g_strdup_printf("ls -R %s",TEST_ROOT_DIR);
+  fprintf(stderr, "ls -R\n");
+  system(command);
+  g_free(command);
+  fprintf(stderr, "\n");
+}
+
 extern int main(int argc, char **argv) {
-  int i, mode;
+  fprintf(stderr, "---- \n");
+  fprintf(stderr, "rm_r[%s] [%d]\n", TEST_ROOT_DIR, rm_r(TEST_ROOT_DIR));
+  fprintf(stderr, "mkdir_p[%s] [%d]\n", TEST_ROOT_DIR, mkdir_p(TEST_ROOT_DIR, 0700));
+  touch(TEST_ROOT_DIR);
+  ls_R();
 
-  if (argc < 3) {
-    fprintf(stderr, "%% testfileutils <MakeDir|mkdir_p|rm_r> dir1 dir2 ...\n");
-    exit(1);
-  }
-  if (!strcmp(argv[1], "MakeDir")) {
-    mode = 1;
-  } else if (!strcmp(argv[1], "mkdir_p")) {
-    mode = 2;
-  } else if (!strcmp(argv[1], "rm_r")) {
-    mode = 3;
-  } else {
-    fprintf(stderr, "%% testfileutils <MakeDir|mkdir_p|rm_r> dir1 dir2 ...\n");
-    exit(1);
-  }
+  fprintf(stderr, "---- \n");
+  fprintf(stderr, "MakeDir[%s] [%d]\n", TEST_MAKE_DIR, MakeDir(TEST_MAKE_DIR, 0700));
+  touch(TEST_MAKE_DIR);
+  ls_R();
 
-  for (i = 2; i < argc; i++) {
-    switch (mode) {
-    case 1:
-      fprintf(stderr, "MakeDir[%s] [%d]\n", argv[i], MakeDir(argv[i], 0700));
-      break;
-    case 2:
-      fprintf(stderr, "mkdir_p[%s] [%d]\n", argv[i], mkdir_p(argv[i], 0700));
-      break;
-    case 3:
-      fprintf(stderr, "rm_r[%s] [%d]\n", argv[i], rm_r(argv[i]));
-      break;
-    }
-  }
+  fprintf(stderr, "---- \n");
+  fprintf(stderr, "rm_r[%s] [%d]\n", TEST_MAKE_DIR, rm_r(TEST_MAKE_DIR));
+  ls_R();
+
+  fprintf(stderr, "---- \n");
+  fprintf(stderr, "mkdir_p[%s] [%d]\n", TEST_RM_R_OLD, mkdir_p(TEST_RM_R_OLD, 0700));
+  touch(TEST_RM_R_OLD);
+  fprintf(stderr, "mkdir_p[%s] [%d]\n", TEST_RM_R_OLD3, mkdir_p(TEST_RM_R_OLD3, 0700));
+  touch(TEST_RM_R_OLD2);
+  touch(TEST_RM_R_OLD3);
+  ls_R();
+
+  fprintf(stderr, "rm_r_old_level(%s,500,0,1) \n", TEST_RM_R_OLD);
+  rm_r_old_level(TEST_RM_R_OLD,500,0,1);
+  ls_R();
+
+  fprintf(stderr, "sleep(5)\n");
+  sleep(5);
+
+  fprintf(stderr, "rm_r_old_level(%s,4,0,2) \n", TEST_RM_R_OLD);
+  rm_r_old_level(TEST_RM_R_OLD,4,0,2);
+  ls_R();
+
   return 0;
 }


### PR DESCRIPTION
* wfcでも利用したいのでpanda/glclient/utils.cからrm_r_old()をlibmondaiへと移動
    * rm_rf_old() https://github.com/montsuqi/panda/blob/master/glclient/utils.c#L130
* 削除するパスの深さを指定するrm_r_old_depth()を追加実装 
    * wfcでTEMPDIR_ROOT以下のファイル、ディレクトリを削除したい
    * rm_rだと指定したパスも削除してしまうため
* testfileutils.cをコマンド風から単体テスト風に変更